### PR TITLE
Closes #63 Stolen type as a default in the filters

### DIFF
--- a/app/src/main/kotlin/com/sonkins/bikeindex/features/bikes/filter/FilterModel.kt
+++ b/app/src/main/kotlin/com/sonkins/bikeindex/features/bikes/filter/FilterModel.kt
@@ -37,7 +37,7 @@ data class FilterModel(
             null,
             null,
             null,
-            Type.ALL,
+            Type.STOLEN,
                 null,
             1,
             25
@@ -59,7 +59,7 @@ data class FilterModel(
             activeFilters++
         }
 
-        if (type == Type.STOLEN || type == Type.NOT_STOLEN) {
+        if (type == Type.ALL || type == Type.NOT_STOLEN) {
             activeFilters++
         }
 
@@ -71,9 +71,9 @@ data class FilterModel(
     }
 
     enum class Type(val type: String, val value: String) {
-        ALL("All", "all"),
         STOLEN("Stolen", "stolen"),
         NOT_STOLEN("Not stolen", "non"),
+        ALL("All", "all"),
         PROXIMITY("Proximity", "proximity")
     }
 }

--- a/app/src/main/res/layout/fragment_filter.xml
+++ b/app/src/main/res/layout/fragment_filter.xml
@@ -262,14 +262,6 @@
                     app:layout_constraintTop_toBottomOf="@id/textViewTypeTitle">
 
                     <RadioButton
-                        android:id="@+id/typeAll"
-                        style="@style/Body1"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:paddingEnd="8dp"
-                        android:text="@string/type_all" />
-
-                    <RadioButton
                         android:id="@+id/typeStolen"
                         style="@style/Body1"
                         android:layout_width="wrap_content"
@@ -284,6 +276,15 @@
                         android:layout_height="wrap_content"
                         android:paddingEnd="8dp"
                         android:text="@string/type_not_stolen" />
+
+                    <RadioButton
+                        android:id="@+id/typeAll"
+                        style="@style/Body1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingEnd="8dp"
+                        android:text="@string/type_all" />
+
                 </RadioGroup>
 
             </androidx.constraintlayout.widget.ConstraintLayout>
@@ -293,8 +294,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:clickable="true"
-                android:focusable="true"
-                android:visibility="gone">
+                android:focusable="true">
 
                 <View
                     android:layout_width="match_parent"


### PR DESCRIPTION
Make the stolen type as a default in the filters, so the stolen location is visible from the start